### PR TITLE
Add preprocessing, training & inference docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,49 @@
 # SIREN: Symbolic Inference of Repetitive Embodied Narratives
+
+This repository demonstrates a multimodal gesture recognition pipeline using the
+**FusionNet** architecture. The network merges sequence embeddings from a CNN or
+Transformer encoder with symbolic features extracted on the fly.
+
+## 1. Preprocessing
+
+The raw dataset (as provided on Kaggle) contains `train.csv` and `test.csv`.
+Run the preprocessing script to clean, pad and z-score each sequence:
+
+```bash
+python scripts/preprocess_data.py \
+    --data_dir /path/to/raw_kaggle_data \
+    --out_dir  /path/to/clean_data
+```
+
+This writes `train_processed.csv`, `test_processed.csv` and
+`label_map.json` to the specified output directory.
+
+## 2. Training
+
+Training uses the new FusionNet architecture and computes symbolic features
+on the fly.
+
+```bash
+python scripts/train_fusion_model.py \
+    --data-dir /path/to/clean_data \
+    --model-type transformer \
+    --fusion gated \
+    --epochs 40 \
+    --batch 64
+```
+
+The best model weights are saved to `artifacts/best_fusion.pt`.
+
+## 3. Inference
+
+Generate predictions on the test split with `run_inference.py`:
+
+```bash
+python scripts/run_inference.py \
+    --data-dir /path/to/clean_data \
+    --model-path artifacts/best_fusion.pt \
+    --out-csv predictions.csv
+```
+
+The resulting CSV contains `sequence_id` and `gesture_id` columns
+ready for submission.

--- a/scripts/run_inference.py
+++ b/scripts/run_inference.py
@@ -1,1 +1,111 @@
-# Run inference
+#!/usr/bin/env python
+"""Run inference with a trained FusionNet model."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import List, Tuple
+
+import numpy as np
+import pandas as pd
+import torch
+from torch.utils.data import DataLoader
+
+from src.data.loader import get_dataset
+from src.features.feature_bank import SymbolicFeatureBank
+from src.models.cnn_encoder import CNNEncoder
+from src.models.transformer_encoder import TransformerEncoder
+from src.models.fusion_net import FusionNet
+
+
+# ---------------------------------------------------------------------------
+def collate_fn(batch, bank: SymbolicFeatureBank) -> Tuple[torch.Tensor, torch.Tensor, List[str]]:
+    seqs, _, ids = zip(*batch)
+    seqs_t = torch.stack(seqs)
+    sym_np = np.vstack([bank.extract_all(s.cpu().numpy()) for s in seqs_t])
+    sym_t = torch.from_numpy(sym_np).float()
+    return seqs_t, sym_t, list(ids)
+
+
+# ---------------------------------------------------------------------------
+def build_encoder(model_type: str, in_ch: int, num_classes: int) -> torch.nn.Module:
+    if model_type == "cnn":
+        return CNNEncoder(in_channels=in_ch, n_classes=num_classes, latent_dim=128)
+    if model_type == "transformer":
+        return TransformerEncoder(
+            in_channels=in_ch,
+            n_classes=num_classes,
+            latent_dim=128,
+            n_layers=4,
+            n_heads=4,
+        )
+    raise ValueError(f"unknown model_type '{model_type}'")
+
+
+# ---------------------------------------------------------------------------
+def run(args: argparse.Namespace) -> None:
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    data_root = Path(args.data_dir)
+
+    with open(data_root / "label_map.json") as jf:
+        num_classes = len(json.load(jf))
+
+    ds = get_dataset(
+        data_root,
+        split="test",
+        use_imu=True,
+        use_thermo=not args.no_thermo,
+        use_tof=not args.no_tof,
+    )
+    bank = SymbolicFeatureBank(ds.sensor_cols)
+
+    loader = DataLoader(
+        ds,
+        batch_size=args.batch,
+        shuffle=False,
+        num_workers=0,
+        pin_memory=True,
+        collate_fn=lambda b: collate_fn(b, bank),
+    )
+
+    encoder = build_encoder(args.model_type, len(ds.sensor_cols), num_classes)
+    model = FusionNet(
+        encoder,
+        sym_dim=bank.dim(),
+        n_classes=num_classes,
+        fusion_type=args.fusion,
+        pool=args.pool,
+    ).to(device)
+
+    model.load_state_dict(torch.load(args.model_path, map_location=device))
+    model.eval()
+
+    preds = []
+    seq_ids = []
+    with torch.no_grad():
+        for seqs, syms, ids in loader:
+            out = model(seqs.to(device), syms.to(device))
+            pred = out.argmax(1).cpu().numpy()
+            preds.extend(pred.tolist())
+            seq_ids.extend(ids)
+
+    df = pd.DataFrame({"sequence_id": seq_ids, "gesture_id": preds})
+    df.to_csv(args.out_csv, index=False)
+    print(f"[inference] wrote predictions → {args.out_csv}")
+
+
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    p = argparse.ArgumentParser(description="Run inference with a trained model")
+    p.add_argument("--data-dir", required=True, help="Folder with *_processed.csv")
+    p.add_argument("--model-path", required=True, help="Path to saved model.pt")
+    p.add_argument("--out-csv", required=True, help="Destination CSV for predictions")
+    p.add_argument("--model-type", choices=["cnn", "transformer"], default="transformer")
+    p.add_argument("--fusion", choices=["concat", "gated"], default="gated")
+    p.add_argument("--pool", choices=["mean", "cls"], default="mean")
+    p.add_argument("--no-thermo", action="store_true")
+    p.add_argument("--no-tof", action="store_true")
+    p.add_argument("--batch", type=int, default=64)
+    run(p.parse_args())


### PR DESCRIPTION
## Summary
- expand README with preprocessing, training and inference instructions
- implement `run_inference.py` for generating predictions

## Testing
- `python -m py_compile scripts/run_inference.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f546140208322ba0011215293cec7