### PR TITLE
Add windowed preprocessing utilities

### DIFF
--- a/scripts/preprocess_data.py
+++ b/scripts/preprocess_data.py
@@ -13,7 +13,7 @@ $ python scripts/preprocess_data.py \
 """
 import argparse
 from pathlib import Path
-from src.data.preprocessing import run_preprocessing
+from src.data.preprocessing import run_preprocessing, SEQ_LEN
 
 
 def main():
@@ -22,12 +22,24 @@ def main():
                    help="Folder with raw train.csv / test.csv from Kaggle")
     p.add_argument("--out_dir",  required=True,
                    help="Destination folder for *_processed.csv & label_map.json")
+    p.add_argument("--frames", type=int, default=SEQ_LEN,
+                   help="Target number of frames after resampling")
+    p.add_argument("--window", type=int, default=None,
+                   help="Length of sliding windows (default: frames)")
+    p.add_argument("--stride", type=int, default=None,
+                   help="Stride between windows (default: window size)")
     args = p.parse_args()
 
     data_dir = Path(args.data_dir)
     out_dir  = Path(args.out_dir)
 
-    run_preprocessing(data_dir=data_dir, out_dir=out_dir)
+    run_preprocessing(
+        data_dir=data_dir,
+        out_dir=out_dir,
+        n_frames=args.frames,
+        window_size=args.window,
+        window_stride=args.stride,
+    )
     print("[preprocess_data] complete.")
 
 

--- a/src/data/windowing.py
+++ b/src/data/windowing.py
@@ -1,1 +1,44 @@
-# Time-series windowing logic
+"""Utility helpers for segmenting a time-series into fixed windows."""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def sliding_window(seq: np.ndarray, window: int, stride: int) -> np.ndarray:
+    """Return an array of shape ``(N, window, F)`` comprised of sliding windows.
+
+    Parameters
+    ----------
+    seq : np.ndarray
+        Input array of shape ``(T, F)``.
+    window : int
+        Length of each window.
+    stride : int
+        Step size between windows.
+
+    Returns
+    -------
+    np.ndarray
+        Array of windows.  If ``T < window`` the sequence is padded with the
+        edge value so at least one window is produced.
+    """
+
+    if window <= 0 or stride <= 0:
+        raise ValueError("window and stride must be positive")
+
+    t, f = seq.shape
+    if t < window:
+        pad = window - t
+        seq = np.pad(seq, ((0, pad), (0, 0)), mode="edge")
+        t = window
+
+    starts = np.arange(0, t - window + 1, stride)
+    if starts.size == 0:
+        starts = np.array([0])
+
+    windows = np.stack([seq[s : s + window] for s in starts])
+    return windows
+
+
+__all__ = ["sliding_window"]


### PR DESCRIPTION
## Summary
- implement sliding window helper
- expand preprocessing to normalise streams independently
- resample sequences, apply tremor entropy and segment into windows
- expose windowing options via CLI script

## Testing
- `pytest -q`
- `python -m py_compile src/data/preprocessing.py src/data/windowing.py scripts/preprocess_data.py`

------
https://chatgpt.com/codex/tasks/task_e_683f546c47748322a856bc1a941cd1de