### PR TITLE
Add encoders for IMU, Thermo and ToF streams

### DIFF
--- a/src/models/imu_encoder.py
+++ b/src/models/imu_encoder.py
@@ -1,0 +1,90 @@
+"""
+IMU sequence encoder combining a temporal CNN with a bidirectional GRU.
+
+* Input  : ``(B, T, F)`` or ``(T, F)``
+* Output : latent vector ``(B, latent_dim)``
+
+The interface mirrors :class:`CNNEncoder` so that it can be swapped into
+:class:`FusionNet` without changes.
+"""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+try:
+    import torch
+    import torch.nn as nn
+except ModuleNotFoundError:  # pragma: no cover - torch missing
+    raise ModuleNotFoundError(
+        "PyTorch is required for imu_encoder.py.\n"
+        "Install with   pip install torch   (CPU build is fine)."
+    )
+
+
+# ---------------------------------------------------------------------------
+class IMUEncoder(nn.Module):
+    """Temporal CNN + Bi-GRU encoder for IMU streams."""
+
+    def __init__(
+        self,
+        in_channels: int = 7,
+        n_classes: int = 18,
+        latent_dim: int = 128,
+        gru_layers: int = 1,
+    ) -> None:
+        super().__init__()
+        self.latent_dim = latent_dim
+        self.n_classes = n_classes
+
+        # simple temporal CNN backbone
+        self.conv = nn.Sequential(
+            nn.Conv1d(in_channels, 64, kernel_size=5, padding=2),
+            nn.BatchNorm1d(64),
+            nn.ReLU(inplace=True),
+            nn.Conv1d(64, latent_dim, kernel_size=3, padding=1),
+            nn.BatchNorm1d(latent_dim),
+            nn.ReLU(inplace=True),
+        )
+
+        # bidirectional GRU over conv features
+        self.gru = nn.GRU(
+            input_size=latent_dim,
+            hidden_size=latent_dim // 2,
+            num_layers=gru_layers,
+            batch_first=True,
+            bidirectional=True,
+        )
+
+        self.classifier = nn.Linear(latent_dim, n_classes)
+
+    # ------------------------------------------------------------------
+    def forward(
+        self, x: torch.Tensor, return_logits: bool = False
+    ) -> torch.Tensor | Tuple[torch.Tensor, torch.Tensor]:
+        if x.ndim == 2:
+            x = x.unsqueeze(0)
+
+        # CNN expects (B, C, T)
+        h = self.conv(x.permute(0, 2, 1))  # (B, latent_dim, T)
+        h = h.permute(0, 2, 1)             # (B, T, latent_dim)
+
+        _, h_n = self.gru(h)               # h_n: (layers*2, B, latent_dim//2)
+        # take last layer's forward & backward states
+        latent = torch.cat([h_n[-2], h_n[-1]], dim=1)
+        logits = self.classifier(latent)
+
+        return (latent, logits) if return_logits else latent
+
+    # ------------------------------------------------------------------
+    def get_output_dim(self) -> int:
+        """Return dimensionality of the latent vector."""
+        return self.latent_dim
+
+
+if __name__ == "__main__":  # pragma: no cover - smoke test
+    B, T, F = 4, 200, 7
+    x = torch.randn(B, T, F)
+    model = IMUEncoder(in_channels=F, n_classes=18, latent_dim=128)
+    lat, log = model(x, return_logits=True)
+    print("latent", lat.shape, "logits", log.shape)

--- a/src/models/thermo_encoder.py
+++ b/src/models/thermo_encoder.py
@@ -1,0 +1,83 @@
+"""
+Thermopile stream encoder using a shallow Conv1D backbone and
+attention pooling.  Suitable for drop-in use with ``FusionNet``.
+"""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+try:
+    import torch
+    import torch.nn as nn
+    import torch.nn.functional as F
+except ModuleNotFoundError:  # pragma: no cover
+    raise ModuleNotFoundError(
+        "PyTorch is required for thermo_encoder.py.\n"
+        "Install with   pip install torch   (CPU build is fine)."
+    )
+
+
+# ---------------------------------------------------------------------------
+class _AttPool(nn.Module):
+    """Simple attention pooling over the temporal dimension."""
+
+    def __init__(self, dim: int) -> None:
+        super().__init__()
+        self.score = nn.Linear(dim, 1)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # x: (B, T, D)
+        w = self.score(x)                # (B, T, 1)
+        w = F.softmax(w, dim=1)
+        return torch.sum(w * x, dim=1)   # (B, D)
+
+
+# ---------------------------------------------------------------------------
+class ThermoEncoder(nn.Module):
+    """Shallow Conv1D encoder with attention pooling."""
+
+    def __init__(
+        self,
+        in_channels: int = 1,
+        n_classes: int = 18,
+        latent_dim: int = 64,
+    ) -> None:
+        super().__init__()
+        self.latent_dim = latent_dim
+        self.n_classes = n_classes
+
+        self.conv = nn.Sequential(
+            nn.Conv1d(in_channels, latent_dim, kernel_size=3, padding=1),
+            nn.ReLU(inplace=True),
+            nn.Conv1d(latent_dim, latent_dim, kernel_size=3, padding=1),
+            nn.ReLU(inplace=True),
+        )
+
+        self.pool = _AttPool(latent_dim)
+        self.classifier = nn.Linear(latent_dim, n_classes)
+
+    # ------------------------------------------------------------------
+    def forward(
+        self, x: torch.Tensor, return_logits: bool = False
+    ) -> torch.Tensor | Tuple[torch.Tensor, torch.Tensor]:
+        if x.ndim == 2:
+            x = x.unsqueeze(0)
+
+        h = self.conv(x.permute(0, 2, 1))  # (B, D, T)
+        h = h.permute(0, 2, 1)             # (B, T, D)
+        latent = self.pool(h)
+        logits = self.classifier(latent)
+        return (latent, logits) if return_logits else latent
+
+    # ------------------------------------------------------------------
+    def get_output_dim(self) -> int:
+        return self.latent_dim
+
+
+if __name__ == "__main__":  # pragma: no cover
+    B, T, F = 4, 200, 1
+    x = torch.randn(B, T, F)
+    model = ThermoEncoder(in_channels=F)
+    lat, log = model(x, return_logits=True)
+    print("latent", lat.shape, "logits", log.shape)

--- a/src/models/tof_encoder.py
+++ b/src/models/tof_encoder.py
@@ -1,0 +1,112 @@
+"""
+Time-of-Flight (ToF) grid encoder using a lightweight Swin-style
+Transformer backbone followed by a GRU.  Each frame is interpreted as
+``in_channels`` × ``img_size`` × ``img_size`` and processed independently
+before temporal aggregation with a GRU.
+"""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+try:
+    import torch
+    import torch.nn as nn
+except ModuleNotFoundError:  # pragma: no cover
+    raise ModuleNotFoundError(
+        "PyTorch is required for tof_encoder.py.\n"
+        "Install with   pip install torch   (CPU build is fine)."
+    )
+
+
+# ---------------------------------------------------------------------------
+class _SwinBlock(nn.Module):
+    """Minimal Swin-style transformer block."""
+
+    def __init__(self, dim: int, num_heads: int) -> None:
+        super().__init__()
+        self.norm1 = nn.LayerNorm(dim)
+        self.attn = nn.MultiheadAttention(dim, num_heads, batch_first=True)
+        self.norm2 = nn.LayerNorm(dim)
+        self.ff = nn.Sequential(
+            nn.Linear(dim, dim * 4),
+            nn.GELU(),
+            nn.Linear(dim * 4, dim),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        h = self.attn(self.norm1(x), self.norm1(x), self.norm1(x))[0]
+        x = x + h
+        x = x + self.ff(self.norm2(x))
+        return x
+
+
+class _MiniSwin(nn.Module):
+    """Very small patch-based transformer used as backbone."""
+
+    def __init__(self, in_ch: int, img_size: int, patch: int, dim: int, depth: int, heads: int) -> None:
+        super().__init__()
+        self.patch_embed = nn.Conv2d(in_ch, dim, kernel_size=patch, stride=patch)
+        num_patches = (img_size // patch) ** 2
+        self.pos = nn.Parameter(torch.zeros(1, num_patches, dim))
+        self.blocks = nn.ModuleList([_SwinBlock(dim, heads) for _ in range(depth)])
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.patch_embed(x)              # (B, dim, H', W')
+        x = x.flatten(2).transpose(1, 2)     # (B, N, dim)
+        x = x + self.pos[:, : x.size(1)]
+        for blk in self.blocks:
+            x = blk(x)
+        return x.mean(dim=1)                 # (B, dim)
+
+
+# ---------------------------------------------------------------------------
+class ToFEncoder(nn.Module):
+    """Swin-style ToF encoder followed by a GRU."""
+
+    def __init__(
+        self,
+        in_channels: int = 5,
+        img_size: int = 8,
+        n_classes: int = 18,
+        latent_dim: int = 128,
+        depth: int = 2,
+        heads: int = 4,
+    ) -> None:
+        super().__init__()
+        self.latent_dim = latent_dim
+        self.img_size = img_size
+        self.in_channels = in_channels
+
+        self.swin = _MiniSwin(in_channels, img_size, patch=2, dim=latent_dim, depth=depth, heads=heads)
+        self.gru = nn.GRU(latent_dim, latent_dim, batch_first=True)
+        self.classifier = nn.Linear(latent_dim, n_classes)
+
+    # ------------------------------------------------------------------
+    def forward(
+        self, x: torch.Tensor, return_logits: bool = False
+    ) -> torch.Tensor | Tuple[torch.Tensor, torch.Tensor]:
+        if x.ndim == 2:
+            x = x.unsqueeze(0)
+
+        B, T, F = x.shape
+        frame = x.view(B * T, self.in_channels, self.img_size, self.img_size)
+        feat = self.swin(frame)                 # (B*T, latent_dim)
+        feat = feat.view(B, T, self.latent_dim) # (B, T, latent_dim)
+
+        _, h_n = self.gru(feat)
+        latent = h_n[-1]
+        logits = self.classifier(latent)
+        return (latent, logits) if return_logits else latent
+
+    # ------------------------------------------------------------------
+    def get_output_dim(self) -> int:
+        return self.latent_dim
+
+
+if __name__ == "__main__":  # pragma: no cover
+    B, T = 2, 10
+    dummy = torch.randn(B, T, 5 * 8 * 8)
+    model = ToFEncoder()
+    out, log = model(dummy, return_logits=True)
+    print("latent", out.shape, "logits", log.shape)


### PR DESCRIPTION
## Summary
- add IMUEncoder implementing a small temporal CNN followed by a BiGRU
- add ThermoEncoder with shallow Conv1d backbone and attention pooling
- add ToFEncoder using a small Swin-style transformer and GRU

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f54344094832293674148b61fac23