### PR TITLE
Add unit tests and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+          pip install pytest
+      - name: Run tests
+        run: pytest -v

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,3 @@
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -1,1 +1,42 @@
-# Unit tests for data loader
+import numpy as np
+import pandas as pd
+from pathlib import Path
+
+from src.data import preprocessing as pp
+from src.data.loader import SequenceDataset, ALL_COLUMNS, SEQ_LEN
+
+
+def test_zscore_normalisation():
+    rng = np.random.RandomState(0)
+    x = rng.rand(50, 3).astype(np.float32)
+    z = pp._zscore(x)
+    assert z.shape == x.shape
+    assert np.allclose(z.mean(axis=0), 0, atol=1e-6)
+    assert np.allclose(z.std(axis=0), 1, atol=1e-6)
+
+
+def test_pad_or_crop():
+    rng = np.random.RandomState(1)
+    short = rng.rand(150, 4).astype(np.float32)
+    long = rng.rand(250, 4).astype(np.float32)
+    assert pp._pad_or_crop(short).shape == (SEQ_LEN, 4)
+    assert pp._pad_or_crop(long).shape == (SEQ_LEN, 4)
+
+
+def test_sequence_dataset_shapes(tmp_path):
+    rows = []
+    for sid in ["A", "B"]:
+        for i in range(SEQ_LEN):
+            frame = np.random.randn(len(ALL_COLUMNS)).astype(np.float32)
+            rows.append([sid, 0, *frame])
+    df = pd.DataFrame(rows, columns=["sequence_id", "gesture_id", *ALL_COLUMNS])
+    csv = tmp_path / "train_processed.csv"
+    df.to_csv(csv, index=False)
+
+    ds = SequenceDataset(csv, mode="train", use_torch=False, use_imu=True, use_thermo=False, use_tof=False)
+    assert len(ds) == 2
+    x, label, sid = ds[0]
+    assert x.shape == (SEQ_LEN, 7)
+    assert isinstance(label, int)
+    assert sid in {"A", "B"}
+

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -1,1 +1,39 @@
-# Unit tests for feature extractors
+import numpy as np
+
+from src.features.thermo_extractor import ThermoExtractor
+from src.features.tof_extractor import ToFExtractor, TOTAL_PIX
+from src.features.rhythmicity import RhythmicityExtractor
+
+
+def test_thermo_extractor_mean():
+    data = np.full((200, 5), 30.0, dtype=np.float32)
+    seq = np.concatenate([np.zeros((200, 7)), data], axis=1)
+    ext = ThermoExtractor(start_idx=7)
+    vec = ext.extract(seq)
+    assert vec.shape == (5,)
+    assert np.allclose(vec, 30.0)
+
+
+def test_tof_extractor_shape_and_values():
+    const_val = 100
+    grid = np.full((200, TOTAL_PIX), const_val, dtype=np.int16)
+    grid[0, 0] = -1  # inject missing pixel
+    seq = np.concatenate([np.zeros((200, 12)), grid], axis=1)
+    ext = ToFExtractor(start_idx=12)
+    vec = ext.extract(seq)
+    assert vec.shape == (4,)
+    expected_mean = const_val / 255.0
+    assert np.isclose(vec[0], expected_mean, atol=1e-6)
+    assert vec[2] < 1.0  # valid ratio less than 1 due to missing pixel
+
+
+def test_rhythmicity_extractor_frequency():
+    fs = 50
+    t = np.arange(0, 4, 1 / fs)
+    sig = np.sin(2 * np.pi * 2.0 * t)
+    seq = np.tile(sig[:, None], (1, 7)).astype(np.float32)
+    ext = RhythmicityExtractor(sample_rate=fs)
+    vec = ext.extract(seq)
+    assert vec.shape == (3,)
+    assert 0.0 < vec[0] < fs / 2
+

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,1 +1,60 @@
-# Unit tests for models
+import torch
+from src.models.cnn_encoder import CNNEncoder
+from src.models.transformer_encoder import TransformerEncoder
+from src.models.fusion_net import FusionNet
+
+
+def test_cnn_encoder_output_dim():
+    B, T, F = 4, 200, 7
+    x = torch.randn(B, T, F)
+    model = CNNEncoder(in_channels=F, n_classes=5, latent_dim=16)
+    lat = model(x)
+    assert lat.shape == (B, 16)
+    assert model.get_output_dim() == 16
+    lat2, logits = model(x, return_logits=True)
+    assert lat2.shape == (B, 16)
+    assert logits.shape == (B, 5)
+
+
+def test_transformer_encoder_output_dim():
+    B, T, F = 3, 200, 20
+    x = torch.randn(B, T, F)
+    model = TransformerEncoder(in_channels=F, n_classes=5, latent_dim=32, n_layers=1, n_heads=4)
+    lat = model(x)
+    assert lat.shape == (B, 32)
+    assert model.get_output_dim() == 32
+    lat2, logits = model(x, return_logits=True)
+    assert lat2.shape == (B, 32)
+    assert logits.shape == (B, 5)
+
+
+def test_fusion_shapes_concat_and_gated():
+    B, T, F = 2, 200, 10
+    seq = torch.randn(B, T, F)
+    sym = torch.randn(B, 6)
+    enc = CNNEncoder(in_channels=F, n_classes=5, latent_dim=8)
+
+    concat = FusionNet(enc, sym_dim=6, n_classes=5, fusion_type="concat")
+    fused, logits = concat(seq, sym, return_latent=True)
+    assert fused.shape == (B, enc.get_output_dim() + 6)
+    assert logits.shape == (B, 5)
+
+    gated = FusionNet(enc, sym_dim=6, n_classes=5, fusion_type="gated")
+    fused_g, logits_g = gated(seq, sym, return_latent=True)
+    assert fused_g.shape == (B, enc.get_output_dim())
+    assert logits_g.shape == (B, 5)
+
+
+def test_meta_fusion_average():
+    B, T, F = 2, 200, 10
+    seq = torch.randn(B, T, F)
+    sym = torch.randn(B, 6)
+    enc1 = CNNEncoder(in_channels=F, n_classes=5, latent_dim=8)
+    enc2 = CNNEncoder(in_channels=F, n_classes=5, latent_dim=8)
+    model1 = FusionNet(enc1, sym_dim=6, n_classes=5)
+    model2 = FusionNet(enc2, sym_dim=6, n_classes=5)
+    logits1 = model1(seq, sym)
+    logits2 = model2(seq, sym)
+    meta = torch.stack([logits1, logits2]).mean(dim=0)
+    assert meta.shape == (B, 5)
+


### PR DESCRIPTION
## Summary
- expand data loader tests for preprocessing and dataset shape
- cover feature extractors for sensor-specific encoders
- test CNN/Transformer encoders and fusion modules
- add pytest-based GitHub Actions workflow

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f5466f2ac832299113d3c47496001