### PR TITLE
Improve docs and clean inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,41 @@
 # SIREN: Symbolic Inference of Repetitive Embodied Narratives
 
-This repository demonstrates a multimodal gesture recognition pipeline using the
-**FusionNet** architecture. The network merges sequence embeddings from a CNN or
-Transformer encoder with symbolic features extracted on the fly.
+This repository implements **SIREN** – a multimodal gesture recognition system
+combining learnable sensor encoders and lightweight symbolic features.  The
+project targets IMU, Thermopile and ToF streams and follows a two‑stage design:
+
+1. *Sensor–wise encoders* produce latent vectors for each modality.
+2. *Symbolic overlays* fuse handcrafted features with the learned latents.
+3. *Meta fusion* merges the three streams and feeds both a multiclass head and
+   per‑class binary heads.
+
+An optional ensemble decoder further mixes binary and multiclass confidence
+scores together with rule based overrides.
 
 ## 1. Preprocessing
 
 The raw dataset (as provided on Kaggle) contains `train.csv` and `test.csv`.
-Run the preprocessing script to clean, pad and z-score each sequence:
+Run the preprocessing script to clean each sequence, normalise sensor streams
+and optionally segment into sliding windows:
 
 ```bash
 python scripts/preprocess_data.py \
     --data_dir /path/to/raw_kaggle_data \
-    --out_dir  /path/to/clean_data
+    --out_dir  /path/to/clean_data \
+    --frames   200               # resample length
+    --window   200               # window size (optional)
+    --stride   200               # stride between windows
 ```
 
-This writes `train_processed.csv`, `test_processed.csv` and
-`label_map.json` to the specified output directory.
+The script performs per‑stream z‑scoring, linear resampling to the target frame
+count and emits `train_processed.csv`, `test_processed.csv` and
+`label_map.json` in the chosen output directory.
 
 ## 2. Training
 
-Training uses the new FusionNet architecture and computes symbolic features
-on the fly.
+`train_fusion_model.py` trains a single FusionNet that joins one sequence
+encoder with its symbolic overlay.  Sensors can be toggled on/off and either a
+CNN or Transformer backbone may be selected.
 
 ```bash
 python scripts/train_fusion_model.py \
@@ -32,18 +46,39 @@ python scripts/train_fusion_model.py \
     --batch 64
 ```
 
-The best model weights are saved to `artifacts/best_fusion.pt`.
+Weights are written to `artifacts/best_fusion.pt`.
+
+`train_meta_fusion.py` builds on top by combining three FusionNet instances
+into a `MetaFusionNet` with both multiclass and binary heads:
+
+```bash
+python scripts/train_meta_fusion.py \
+    --data-dir /path/to/clean_data \
+    --model-type transformer \
+    --fusion gated \
+    --epochs 40
+```
+
+The best model is stored as `artifacts/best_meta_fusion.pt`.
 
 ## 3. Inference
 
-Generate predictions on the test split with `run_inference.py`:
+Generate predictions on the test split with `run_inference.py`.
+The script loads a saved FusionNet model and optionally applies simple rule
+based overrides on the thermopile stream:
 
 ```bash
 python scripts/run_inference.py \
     --data-dir /path/to/clean_data \
     --model-path artifacts/best_fusion.pt \
-    --out-csv predictions.csv
+    --out-csv predictions.csv \
+    --binary-weight 0.5 \
+    --multi-weight 0.5 \
+    --rules              # enable rule based mask
 ```
 
-The resulting CSV contains `sequence_id` and `gesture_id` columns
-ready for submission.
+The resulting CSV contains `sequence_id` and `gesture_id` columns ready for
+Kaggle submission.
+
+Meta‑fusion models can be served in a similar way once an inference helper is
+added.

--- a/scripts/run_inference.py
+++ b/scripts/run_inference.py
@@ -192,7 +192,5 @@ if __name__ == "__main__":
     parser.add_argument("--no-tof", action="store_true")
     args = parser.parse_args()
     run(args)
-=======
-*
->>>>>>> main
+
 


### PR DESCRIPTION
## Summary
- document the full SIREN pipeline including preprocessing, training, and inference
- fix leftover merge markers in `run_inference.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_683f5369eeb08322ae389912fcd40ea3